### PR TITLE
Fix minor typo

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -96,7 +96,7 @@
           <p>In March 2016, if you were to search for images of CEOs, <a href="https://twitter.com/brunosan/status/712102273430650880">You would only see men</a>, and the first woman would be Barbie. Let's change that.</p>
         </div>
         <div class="col-lg-4">
-          <p>When you create, link, or share create content with the worlds "CEO" and an image, you are building the expectation of results. </p>
+          <p>When you create, link, or share create content with the words "CEO" and an image, you are building the expectation of results. </p>
         </div>
         <div class="col-lg-8 col-lg-offset-2">
           <hr class="star-primary">


### PR DESCRIPTION
> When you create, link, or share create content with the worlds "CEO" and an image

Fix is/was to change `worlds` to `words`
